### PR TITLE
kernel: Swap field order in vga_char struct, fixes VGA output

### DIFF
--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -3,17 +3,17 @@
 
 #define STYLE_WB    0x0F
 
-typedef struct __attribute__((packed)) {
-    char character;
+typedef struct {
     char style;
+    char character;
 } vga_char;
 
-volatile vga_char *text_area = (vga_char*) VGA_START;
+volatile vga_char *text_area = (volatile vga_char*) VGA_START;
 
 void clear_disp() {
     vga_char blank_char = {
+        .style = STYLE_WB,
         .character = ' ',
-        .style = STYLE_WB
     };
 
     for (unsigned int i = 0; i < VGA_EXTENT / 2; i++) {
@@ -24,8 +24,8 @@ void clear_disp() {
 void print_str(const char *str) {
     for (unsigned int i = 0; i < VGA_EXTENT && str[i] != '\0'; i++) {
         vga_char current_char = {
+            .style = STYLE_WB,
             .character = str[i],
-            .style = STYLE_WB
         };
 
         text_area[i] = current_char;


### PR DESCRIPTION
The VGA text-mode buffer interprets the first byte of each word entry as the
style/color and the last byte as the character to display. Update the
vga_char struct to reflect this.

Also update the text_area declaration to properly include volatile in
the cast.